### PR TITLE
Fix DB connection string for Docker

### DIFF
--- a/BourbonWeb/appsettings.json
+++ b/BourbonWeb/appsettings.json
@@ -7,6 +7,6 @@
     },
     "AllowedHosts": "*",
     "ConnectionStrings": {
-        "DefaultConnection": "Server=localhost;Database=BOURBON_AE;User Id=Buser;Password=Bpswd;TrustServerCertificate=True;"
+        "DefaultConnection": "Server=host.docker.internal;Database=BOURBON_AE;User Id=Buser;Password=Bpswd;TrustServerCertificate=True;"
     }
 }


### PR DESCRIPTION
## Summary
- update connection string in `appsettings.json` to reference `host.docker.internal`

## Testing
- `dotnet build BourbonWeb.sln -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a3a19a32c8320a1fff18a17afc2da