### PR TITLE
Configure analyzers and formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Build and Lint
+
+on:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Restore
+        run: dotnet restore
+      - name: Format Check
+        run: dotnet format --verify-no-changes
+      - name: Build
+        run: dotnet build --no-restore --configuration Release

--- a/BourbonWeb/BourbonWeb.csproj
+++ b/BourbonWeb/BourbonWeb.csproj
@@ -16,6 +16,8 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1-Preview.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest</AnalysisLevel>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- add StyleCop and Roslyn analyzers
- configure warnings as errors and formatting rules
- introduce workflow to run `dotnet format` and build

## Testing
- `dotnet format --verify-no-changes` *(fails: dotnet not installed)*
- `dotnet restore` *(fails: dotnet not installed)*


------
https://chatgpt.com/codex/tasks/task_b_685e1cfbc18c8320a0ba403c477ad844