### PR TITLE
Add ProductsController doc

### DIFF
--- a/BourbonWeb/docfx/docs/products-controller.md
+++ b/BourbonWeb/docfx/docs/products-controller.md
@@ -1,0 +1,6 @@
+# ProductsController
+
+`ProductsController` は商品の一覧、詳細、作成、編集、削除などを扱う MVC コントローラーです。各アクションの利用方法については生成された API ドキュメントをご参照ください。
+
+[API リファレンスはこちら](../api/BourbonWeb.Controllers.ProductsController.html)
+

--- a/BourbonWeb/docfx/docs/toc.yml
+++ b/BourbonWeb/docfx/docs/toc.yml
@@ -2,3 +2,5 @@
   href: introduction.md
 - name: Getting Started
   href: getting-started.md
+- name: Products Controller
+  href: products-controller.md

--- a/BourbonWeb/docfx/index.md
+++ b/BourbonWeb/docfx/index.md
@@ -17,3 +17,6 @@ Refer to [Markdown](http://daringfireball.net/projects/markdown/) for how to wri
 ## 📘 APIリファレンス
 
 [こちらからAPIドキュメントを参照できます](api/index.html)
+
+## ProductsController ドキュメント
+[ProductsController の API](api/BourbonWeb.Controllers.ProductsController.html)


### PR DESCRIPTION
## Summary
- create documentation page for ProductsController
- update doc site index and table of contents to reference the new page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68664e566e588320aa3e53efba8e89f6