### PR TITLE
Refine layout for full HD

### DIFF
--- a/BourbonWeb/Views/Shared/_Layout.cshtml
+++ b/BourbonWeb/Views/Shared/_Layout.cshtml
@@ -6,13 +6,14 @@
     <title>@ViewData["Title"] - BourbonWeb</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/sidebar.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/BourbonWeb.styles.css" asp-append-version="true" />
 </head>
-<body>
+<body class="d-flex flex-column min-vh-100">
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
             <div class="container-fluid">
-                <button class="btn btn-outline-secondary me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebar" aria-controls="sidebar">
+                <button id="sidebarToggle" class="btn btn-outline-secondary me-2" type="button">
                     <span class="navbar-toggler-icon"></span>
                 </button>
                 <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">BourbonWeb</a>
@@ -33,18 +34,8 @@
             </div>
         </nav>
     </header>
-    <div class="container">
-        <main role="main" class="pb-3">
-            @RenderBody()
-        </main>
-    </div>
-
-    <div class="offcanvas offcanvas-start" tabindex="-1" id="sidebar" aria-labelledby="sidebarLabel">
-        <div class="offcanvas-header">
-            <h5 class="offcanvas-title" id="sidebarLabel">メニュー</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
-        </div>
-        <div class="offcanvas-body">
+    <div id="page" class="d-flex flex-grow-1">
+        <nav id="sidebar" class="sidebar">
             <ul class="nav flex-column">
                 <li class="nav-item">
                     <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
@@ -56,6 +47,13 @@
                     <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                 </li>
             </ul>
+        </nav>
+        <div class="flex-grow-1">
+            <div class="container">
+                <main role="main" class="pb-3">
+                    @RenderBody()
+                </main>
+            </div>
         </div>
     </div>
 

--- a/BourbonWeb/wwwroot/css/sidebar.css
+++ b/BourbonWeb/wwwroot/css/sidebar.css
@@ -1,0 +1,24 @@
+#page {
+    display: flex;
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+.sidebar {
+    width: 250px;
+    background-color: #f8f9fa;
+    overflow-x: hidden;
+    transition: width 0.3s ease;
+}
+
+.sidebar.collapsed {
+    width: 60px;
+}
+
+.sidebar .nav-link {
+    white-space: nowrap;
+}
+
+body {
+    margin-bottom: 0;
+}

--- a/BourbonWeb/wwwroot/js/site.js
+++ b/BourbonWeb/wwwroot/js/site.js
@@ -2,3 +2,13 @@
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.
+
+document.addEventListener('DOMContentLoaded', function () {
+    const toggleBtn = document.getElementById('sidebarToggle');
+    const sidebar = document.getElementById('sidebar');
+    if (toggleBtn && sidebar) {
+        toggleBtn.addEventListener('click', function () {
+            sidebar.classList.toggle('collapsed');
+        });
+    }
+});


### PR DESCRIPTION
## Summary
- adjust sidebar flex container sizing
- remove body bottom margin so page fits within viewport at full HD

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b3699f4cc8320b26cdd578826000c