### PR TITLE
Fix sidebar/footer overlap

### DIFF
--- a/BourbonWeb/Views/Shared/_Layout.cshtml
+++ b/BourbonWeb/Views/Shared/_Layout.cshtml
@@ -57,7 +57,7 @@
         </div>
     </div>
 
-    <footer class="border-top footer text-muted">
+    <footer class="border-top footer text-muted mt-auto">
         <div class="container">
             &copy; 2025 - BourbonWeb - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
         </div>

--- a/BourbonWeb/Views/Shared/_Layout.cshtml.css
+++ b/BourbonWeb/Views/Shared/_Layout.cshtml.css
@@ -40,8 +40,6 @@ button.accept-policy {
 }
 
 .footer {
-  position: absolute;
-  bottom: 0;
   width: 100%;
   white-space: nowrap;
   line-height: 60px;


### PR DESCRIPTION
## Summary
- keep footer in normal flow to avoid overlay with sidebar
- let the footer flex to the bottom when content is short

## Testing
- `dotnet build BourbonWeb/BourbonWeb.csproj -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686b5a3c3a608320961f83b3e05a8fa0