### PR TITLE
Persist sidebar state

### DIFF
--- a/BourbonWeb/Views/Shared/_Layout.cshtml
+++ b/BourbonWeb/Views/Shared/_Layout.cshtml
@@ -10,6 +10,15 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/admin-lte@@4.0.0-rc4/dist/css/adminlte.min.css" crossorigin="anonymous" />
 </head>
 <body class="sidebar-expand-lg sidebar-open layout-fixed bg-body-tertiary">
+    <script>
+        (function () {
+            var state = localStorage.getItem('sidebar-state');
+            if (state === 'closed') {
+                document.body.classList.remove('sidebar-open');
+                document.body.classList.add('sidebar-collapse');
+            }
+        })();
+    </script>
     <div class="app-wrapper">
         <nav class="app-header navbar navbar-expand bg-body">
             <div class="container-fluid">

--- a/BourbonWeb/wwwroot/js/site.js
+++ b/BourbonWeb/wwwroot/js/site.js
@@ -5,6 +5,22 @@ const Default = {
     scrollbarAutoHide: 'leave',
     scrollbarClickScroll: true,
 };
+function applySidebarState() {
+    const body = document.body;
+    const storedState = localStorage.getItem('sidebar-state');
+    if (storedState === 'closed') {
+        body.classList.remove('sidebar-open');
+        body.classList.add('sidebar-collapse');
+    }
+}
+
+// Apply sidebar state as early as possible
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applySidebarState);
+} else {
+    applySidebarState();
+}
+
 document.addEventListener('DOMContentLoaded', function () {
     const sidebarWrapper = document.querySelector(SELECTOR_SIDEBAR_WRAPPER);
     if (sidebarWrapper && OverlayScrollbarsGlobal?.OverlayScrollbars !== undefined) {
@@ -14,6 +30,18 @@ document.addEventListener('DOMContentLoaded', function () {
                 autoHide: Default.scrollbarAutoHide,
                 clickScroll: Default.scrollbarClickScroll,
             },
+        });
+    }
+
+    // Save sidebar state whenever it's toggled
+    const sidebarToggler = document.querySelector('[data-lte-toggle="sidebar"]');
+    if (sidebarToggler) {
+        sidebarToggler.addEventListener('click', () => {
+            // Delay to allow AdminLTE to update classes
+            setTimeout(() => {
+                const isClosed = document.body.classList.contains('sidebar-collapse');
+                localStorage.setItem('sidebar-state', isClosed ? 'closed' : 'open');
+            }, 10);
         });
     }
 });


### PR DESCRIPTION
## Summary
- maintain sidebar open/close state across page navigation
- prevent flicker on first page load by applying sidebar state immediately

## Testing
- `dotnet build BourbonWeb.sln`


------
https://chatgpt.com/codex/tasks/task_b_6886d4348818832088bc1fb3874396b2