### PR TITLE
金額列のカンマ編集と右端揃え

### DIFF
--- a/BourbonWeb/Views/Samples/Index.cshtml
+++ b/BourbonWeb/Views/Samples/Index.cshtml
@@ -15,7 +15,7 @@
                     <th>
                         @Html.DisplayNameFor(model => model.Name)
                     </th>
-                    <th>
+                    <th class="text-end">
                         @Html.DisplayNameFor(model => model.Price)
                     </th>
                     <th>
@@ -31,8 +31,8 @@
                         <td>
                             @Html.DisplayFor(modelItem => item.Name)
                         </td>
-                        <td>
-                            @Html.DisplayFor(modelItem => item.Price)
+                        <td class="text-end">
+                            @item.Price.ToString("N0")
                         </td>
                         <td>
                             @Html.DisplayFor(modelItem => item.Description)


### PR DESCRIPTION
## Summary
- 金額列のヘッダーに `text-end` を追加
- 金額を `N0` 書式で表示し、同じく右端揃えに変更

## Testing
- `dotnet test`
- `dotnet build BourbonWeb.sln`


------
https://chatgpt.com/codex/tasks/task_b_68897559c25c8320801efeb6db8a3a64